### PR TITLE
Add mount and unmount methods to the SDCard class and HAL abstraction

### DIFF
--- a/include/hal/PocuterSDCard.h
+++ b/include/hal/PocuterSDCard.h
@@ -20,7 +20,7 @@ class PocuterSDCard {
         /**
         * @brief Cheks if a SDCard is mounted
         * 
-        * @note The Pocuter automatically mounts FAT32 formatted cars to getMountPoint()
+        * @note The Pocuter automatically mounts FAT32 formatted cards to getMountPoint()
         *
         * @return
         *     - true if a card is detected
@@ -39,6 +39,22 @@ class PocuterSDCard {
         *     
         */
         virtual const char* getMountPoint() = 0;
+
+        /**
+        * @brief mount a card if there is an unmounted card present in the slot
+        *
+        * @return
+        *     - true card has been mounted or is already mounted
+        *     - false no card present
+        *     
+        */
+        virtual bool mount();
+
+        /**
+        * @brief unmount card if there is a mounted card
+        */
+        virtual void unmount();
+
     private:
 
 };

--- a/include/hal/esp32-c3/esp32_c3_SDCard.h
+++ b/include/hal/esp32-c3/esp32_c3_SDCard.h
@@ -12,6 +12,8 @@ namespace PocuterLib {
             bool cardInSlot();
             bool cardIsMounted();
             const char* getMountPoint();
+            bool mount();
+            void unmount();
         private:
             sdmmc_card_t *m_card;
             bool m_sdcardMounted;


### PR DESCRIPTION
This pull request adds mount and unmount methods to the SDCard class.

It's a simple refactoring that moves the SDCard constructor/destructor code into the methods mount and unmount