### PR TITLE
Added disable() method to PocuterSleep class

### DIFF
--- a/include/hal/PocuterSleep.h
+++ b/include/hal/PocuterSleep.h
@@ -142,6 +142,17 @@ class PocuterSleep {
         */
         virtual SLEEPERROR setInactivitySleep(uint32_t sec, SLEEPTIMER_INTERRUPTS cause, bool saveTimeout = false) = 0;
         
+        /**
+        * @brief disable sleep timer
+        * 
+        * @note internally call setInactivitySleep with a timeout of 0
+        * 
+        * @return
+        *     - SLEEPERROR_OK 
+        * 
+        */
+        SLEEPERROR disable() { return this->setInactivitySleep( 0, (SLEEPTIMER_INTERRUPTS) 0x03 ); }
+
          /**
         * @brief why did the device waked up?
         * @note wake up by WAKEUP_CAUSE_GPIO could also mean by a button.

--- a/include/hal/PocuterSleep.h
+++ b/include/hal/PocuterSleep.h
@@ -145,7 +145,8 @@ class PocuterSleep {
         /**
         * @brief disable sleep timer
         * 
-        * @note internally call setInactivitySleep with a timeout of 0
+        * @note internally call setInactivitySleep with a timeout of 0 and all interrupt flags
+        * @note there is a race condition between the initialization of the Pocuter object and the creation of the sleep time. There needs to be a suitable delay ~50ms between creating the Pocuter object and calling pocuter->Sleep->disable()
         * 
         * @return
         *     - SLEEPERROR_OK 

--- a/include/hal/PocuterSleep.h
+++ b/include/hal/PocuterSleep.h
@@ -146,7 +146,7 @@ class PocuterSleep {
         * @brief disable sleep timer
         * 
         * @note internally call setInactivitySleep with a timeout of 0 and all interrupt flags
-        * @note there is a race condition between the initialization of the Pocuter object and the creation of the sleep time. There needs to be a suitable delay ~50ms between creating the Pocuter object and calling pocuter->Sleep->disable()
+        * @note there is a race condition between the initialization of the Pocuter object and the creation of the sleep timer. There needs to be a suitable delay ~50ms between creating the Pocuter object and calling pocuter->Sleep->disable()
         * 
         * @return
         *     - SLEEPERROR_OK 


### PR DESCRIPTION
This pull request adds the helper method PocuterSleep->disable()

This method calls PocuterSleep->setInactivitySleep(...) with a timeout of 0 and all interrupt flags set.

This will make it easy for users to disable the sleep timer :)
